### PR TITLE
Fail on missing credentials in apexDiscover()

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,10 +1,10 @@
 lockVersion: 2.0.0
 id: b95067c6-660d-4241-9d59-04829c592eb4
 management:
-  docChecksum: c228280ab24af59505327c759fe66d5f
+  docChecksum: 7c335c3dd2980171feb91c16ef4bab7a
   docVersion: "1.0"
-  speakeasyVersion: 1.480.0
-  generationVersion: 2.499.0
+  speakeasyVersion: 1.481.1
+  generationVersion: 2.500.5
   releaseVersion: 0.5.1
   configChecksum: d55a39df36bbbc4425e7d87605d18535
   published: true
@@ -12,7 +12,7 @@ features:
   typescript:
     additionalDependencies: 0.1.0
     constsAndDefaults: 0.1.11
-    core: 3.18.20
+    core: 3.18.22
     defaultEnabledRetries: 0.1.0
     enumUnions: 0.1.0
     envVarSecurityUsage: 0.1.2

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,9 +1,9 @@
-speakeasyVersion: 1.480.0
+speakeasyVersion: 1.481.1
 sources:
     Acuvity-OAS:
         sourceNamespace: acuvity-oas
-        sourceRevisionDigest: sha256:62ebfa7de6d8870ee00d6217ac1a286baf9f47824467e58bad705eec30ad5b2a
-        sourceBlobDigest: sha256:b385e91e0858fc55af8c1907e20cb3153930b6e1fefbf46e7e1e250015891f7c
+        sourceRevisionDigest: sha256:367d21f38934acd63fa9506e7af8e90fabe1da582466d37f6d63ad70fa1a0536
+        sourceBlobDigest: sha256:cd101e8a39f8de161266ab95e7fe439bd27660a5398fa1a7ab51e6a8e5316ec2
         tags:
             - latest
             - "1.0"
@@ -25,10 +25,10 @@ targets:
     typescript:
         source: Acuvity-OAS
         sourceNamespace: acuvity-oas
-        sourceRevisionDigest: sha256:62ebfa7de6d8870ee00d6217ac1a286baf9f47824467e58bad705eec30ad5b2a
-        sourceBlobDigest: sha256:b385e91e0858fc55af8c1907e20cb3153930b6e1fefbf46e7e1e250015891f7c
+        sourceRevisionDigest: sha256:367d21f38934acd63fa9506e7af8e90fabe1da582466d37f6d63ad70fa1a0536
+        sourceBlobDigest: sha256:cd101e8a39f8de161266ab95e7fe439bd27660a5398fa1a7ab51e6a8e5316ec2
         codeSamplesNamespace: acuvity-oas-typescript-code-samples
-        codeSamplesRevisionDigest: sha256:3e37209e3d973138f7a730d073bcdae46e74410ab4efdfd347fe8078bd5b28f5
+        codeSamplesRevisionDigest: sha256:1c3b5bf7b227bd63c1e246a0e07858ed72468251d8de5bc3300b4ad2b3b6a798
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: latest

--- a/apex-openapi.yaml
+++ b/apex-openapi.yaml
@@ -873,7 +873,7 @@ servers:
     url: https://{apex_domain}:{apex_port}
     variables:
       apex_domain:
-        default: apex.acuvity.ai
+        default: api.apex.acuvity.ai
         description: |-
           The Apex domain to use which is specific to each customer and environment.
           This can be determined through the well known Apex info response from the Acuvity backend API.

--- a/docs/sdks/apex/README.md
+++ b/docs/sdks/apex/README.md
@@ -113,7 +113,6 @@ async function run() {
       "key1": "value1",
       "key2": "value2",
     },
-    anonymization: "FixedSize",
     bypassHash: "6f37d752-bce1-4973-88f6-28b6c100ceb8",
     keywords: [
       "legal",
@@ -165,7 +164,6 @@ async function run() {
       "key1": "value1",
       "key2": "value2",
     },
-    anonymization: "FixedSize",
     bypassHash: "6f37d752-bce1-4973-88f6-28b6c100ceb8",
     keywords: [
       "legal",

--- a/package.json
+++ b/package.json
@@ -2,16 +2,6 @@
   "name": "@acuvity/acuvity",
   "version": "0.5.1",
   "author": "Acuvity, Inc.",
-  "license": "Apache-2.0",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/acuvity/acuvity-ts.git"
-  },
-  "bugs": {
-    "url": "https://github.com/acuvity/acuvity-ts/issues"
-  },
-  "description": "The official Acuvity TypeScript SDK",
-  "homepage": "https://acuvity.ai/",
   "keywords": [
     "security",
     "genai",
@@ -22,6 +12,16 @@
     "library",
     "nodejs"
   ],
+  "license": "Apache-2.0",
+  "repository": {
+    "url": "git+https://github.com/acuvity/acuvity-ts.git",
+    "type": "git"
+  },
+  "bugs": {
+    "url": "https://github.com/acuvity/acuvity-ts/issues"
+  },
+  "description": "The official Acuvity TypeScript SDK",
+  "homepage": "https://acuvity.ai/",
   "type": "module",
   "tshy": {
     "sourceDialects": [
@@ -64,5 +64,77 @@
   "dependencies": {
     "jwt-decode": "^4.0.0",
     "yaml": "^2.7.0"
-  }
+  },
+  "exports": {
+    ".": {
+      "import": {
+        "@acuvity/acuvity/source": "./src/index.ts",
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/index.d.ts",
+        "default": "./dist/commonjs/index.js"
+      }
+    },
+    "./package.json": "./package.json",
+    "./types": {
+      "import": {
+        "@acuvity/acuvity/source": "./src/types/index.ts",
+        "types": "./dist/esm/types/index.d.ts",
+        "default": "./dist/esm/types/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/types/index.d.ts",
+        "default": "./dist/commonjs/types/index.js"
+      }
+    },
+    "./models/errors": {
+      "import": {
+        "@acuvity/acuvity/source": "./src/models/errors/index.ts",
+        "types": "./dist/esm/models/errors/index.d.ts",
+        "default": "./dist/esm/models/errors/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/models/errors/index.d.ts",
+        "default": "./dist/commonjs/models/errors/index.js"
+      }
+    },
+    "./models/components": {
+      "import": {
+        "@acuvity/acuvity/source": "./src/models/components/index.ts",
+        "types": "./dist/esm/models/components/index.d.ts",
+        "default": "./dist/esm/models/components/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/models/components/index.d.ts",
+        "default": "./dist/commonjs/models/components/index.js"
+      }
+    },
+    "./*.js": {
+      "import": {
+        "@acuvity/acuvity/source": "./src/*.ts",
+        "types": "./dist/esm/*.d.ts",
+        "default": "./dist/esm/*.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/*.d.ts",
+        "default": "./dist/commonjs/*.js"
+      }
+    },
+    "./*": {
+      "import": {
+        "@acuvity/acuvity/source": "./src/*.ts",
+        "types": "./dist/esm/*.d.ts",
+        "default": "./dist/esm/*.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/*.d.ts",
+        "default": "./dist/commonjs/*.js"
+      }
+    }
+  },
+  "main": "./dist/commonjs/index.js",
+  "types": "./dist/commonjs/index.d.ts",
+  "module": "./dist/esm/index.js"
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -58,7 +58,7 @@ export function serverURLFromOptions(options: SDKOptions): URL | null {
 
   const serverParams: Params[] = [
     {
-      "apex_domain": options.apexDomain ?? "apex.acuvity.ai",
+      "apex_domain": options.apexDomain ?? "api.apex.acuvity.ai",
       "apex_port": options.apexPort ?? "443",
     },
   ];
@@ -81,6 +81,6 @@ export const SDK_METADATA = {
   language: "typescript",
   openapiDocVersion: "1.0",
   sdkVersion: "0.5.1",
-  genVersion: "2.499.0",
-  userAgent: "speakeasy-sdk/typescript 0.5.1 2.499.0 1.0 @acuvity/acuvity",
+  genVersion: "2.500.5",
+  userAgent: "speakeasy-sdk/typescript 0.5.1 2.500.5 1.0 @acuvity/acuvity",
 } as const;


### PR DESCRIPTION
- fails in `apexDiscover()` if no token has been passed in the security object even before we short-circuit on provided serverURL or apexDomain: this ensures that a token will always be present or fail otherwise
- changing the fallback Apex domain to `api.apex.acuvity.ai`